### PR TITLE
misspelled warning modify

### DIFF
--- a/examples/vnet/doca_ft.c
+++ b/examples/vnet/doca_ft.c
@@ -14,7 +14,7 @@
 
 DOCA_LOG_MODULE(flow_table);
 
-static int _doca_ft_destory_flow(struct doca_ft *ft, struct doca_ft_key *key);
+static int _doca_ft_destroy_flow(struct doca_ft *ft, struct doca_ft_key *key);
 
 struct doca_ft_entry {
 	LIST_ENTRY(doca_ft_entry) next; /* entry pointers in the list. */
@@ -105,7 +105,7 @@ static void *doca_ft_aging_main(void *void_ptr)
 						if (node->expiration < t) {
 							DOCA_LOG_DBG(
 							    "removing flow");
-							_doca_ft_destory_flow(
+							_doca_ft_destroy_flow(
 							    ft, &node->key);
 							still_aging = true;
 							break;
@@ -259,7 +259,7 @@ bool doca_ft_add_new(struct doca_ft *ft, struct doca_pkt_info *pinfo,
 	return true;
 }
 
-static int _doca_ft_destory_flow(struct doca_ft *ft, struct doca_ft_key *key)
+static int _doca_ft_destroy_flow(struct doca_ft *ft, struct doca_ft_key *key)
 {
 	struct doca_ft_entry *f;
 
@@ -278,7 +278,7 @@ static int _doca_ft_destory_flow(struct doca_ft *ft, struct doca_ft_key *key)
 
 int doca_ft_destory_flow(struct doca_ft *ft, struct doca_ft_key *key)
 {
-	return _doca_ft_destory_flow(ft, key);
+	return _doca_ft_destroy_flow(ft, key);
 }
 
 void doca_ft_destroy(struct doca_ft *ft)
@@ -293,7 +293,7 @@ void doca_ft_destroy(struct doca_ft *ft)
 			first = &ft->buckets[i].head;
 			LIST_FOREACH(node, first, next) {
 				LIST_REMOVE(node, next);
-				_doca_ft_destory_flow(ft, &node->key);
+				_doca_ft_destroy_flow(ft, &node->key);
 				continue;
 			}
 		} while (0);

--- a/examples/vnet/doca_gauge.h
+++ b/examples/vnet/doca_gauge.h
@@ -35,7 +35,7 @@ struct doca_gauge_cfg {
 struct doca_gauge *doca_gauge_init(struct doca_gauge_cfg *cfg);
 
 /**
- * @brief - reset to inital state (like new alloc)
+ * @brief - reset to initial state (like new alloc)
  *
  * @param gauge
  */

--- a/examples/vnet/doca_pcap.c
+++ b/examples/vnet/doca_pcap.c
@@ -8,7 +8,7 @@ static const uint32_t DP_MAGIC_NUM_FLIP = 0xd4c3b2a1;
 static const uint32_t DP_MAGIC_NUM_DONT_FLIP = 0xa1b2c3d4;
 static int DP_FLIP;
 
-struct doca_pcap_hander {
+struct doca_pcap_handler {
 	FILE *fd;
 };
 
@@ -29,10 +29,10 @@ struct pcap_pkt_header {
 	uint32_t pkt_len;
 };
 
-struct doca_pcap_hander *doca_pcap_file_start(const char *filename)
+struct doca_pcap_handler *doca_pcap_file_start(const char *filename)
 {
 	size_t n;
-	struct doca_pcap_hander *p_handler;
+	struct doca_pcap_handler *p_handler;
 	struct pcap_file_header hdr;
 	FILE *fd = fopen(filename, "wb");
 
@@ -49,18 +49,18 @@ struct doca_pcap_hander *doca_pcap_file_start(const char *filename)
 
 	n = fwrite(&hdr, 1, sizeof(struct pcap_file_header), fd);
 	p_handler =
-	    (struct doca_pcap_hander *)malloc(sizeof(struct doca_pcap_hander));
+	    (struct doca_pcap_handler *)malloc(sizeof(struct doca_pcap_handler));
 
 	if (n != sizeof(struct pcap_file_header) || p_handler == NULL) {
 		fclose(fd);
 		return NULL;
 	}
-	memset(p_handler, 0, sizeof(struct doca_pcap_hander));
+	memset(p_handler, 0, sizeof(struct doca_pcap_handler));
 	p_handler->fd = fd;
 	return p_handler;
 }
 
-int doca_pcap_write(struct doca_pcap_hander *p_handler, uint8_t *buff,
+int doca_pcap_write(struct doca_pcap_handler *p_handler, uint8_t *buff,
 		    int buff_len, uint64_t timestamp, int cap_len)
 {
 	size_t n;
@@ -79,7 +79,7 @@ int doca_pcap_write(struct doca_pcap_hander *p_handler, uint8_t *buff,
 	return n;
 }
 
-void doca_pcap_file_stop(struct doca_pcap_hander *p_handler)
+void doca_pcap_file_stop(struct doca_pcap_handler *p_handler)
 {
 	fclose(p_handler->fd);
 	free(p_handler);

--- a/examples/vnet/doca_pcap.h
+++ b/examples/vnet/doca_pcap.h
@@ -1,7 +1,7 @@
 #ifndef _DOCA_PCAP_H_
 #define _DOCA_PCAP_H_
 
-struct doca_pcap_hander;
+struct doca_pcap_handler;
 
 /**
  * @brief - start pcap file writer
@@ -10,7 +10,7 @@ struct doca_pcap_hander;
  *
  * @return handler
  */
-struct doca_pcap_hander *doca_pcap_file_start(const char *filename);
+struct doca_pcap_handler *doca_pcap_file_start(const char *filename);
 
 /**
  * @brief - write a packet to file
@@ -23,7 +23,7 @@ struct doca_pcap_hander *doca_pcap_file_start(const char *filename);
  *
  * @return
  */
-int doca_pcap_write(struct doca_pcap_hander *p_handler, uint8_t *buff,
+int doca_pcap_write(struct doca_pcap_handler *p_handler, uint8_t *buff,
 		    int buff_len, uint64_t timestamp, int cap_len);
 
 /**
@@ -31,6 +31,6 @@ int doca_pcap_write(struct doca_pcap_hander *p_handler, uint8_t *buff,
  *
  * @param p_handler
  */
-void doca_pcap_file_stop(struct doca_pcap_hander *p_handler);
+void doca_pcap_file_stop(struct doca_pcap_handler *p_handler);
 
 #endif


### PR DESCRIPTION
_doca_ft_destory_flow to _doca_ft_destroy_flow
doca_pcap_hander to doca_pcap_handler

Signed-off-by: Dong Zhou <dongzhou@nvidia.com>