### PR TITLE
doca-dpdk: update doca API to be paired

### DIFF
--- a/examples/vnet/doca_dpdk.h
+++ b/examples/vnet/doca_dpdk.h
@@ -193,7 +193,7 @@ struct doca_dpdk_action_data {
 		struct doca_dpdk_action_rawdecap_data rawdecap;
 		struct doca_dpdk_action_rawencap_data rawencap;
 		struct doca_dpdk_action_meter_data meter;
-        struct doca_dpdk_action_set_meta meta;
+		struct doca_dpdk_action_set_meta meta;
 		struct doca_dpdk_action_fwd_data fwd;
 		struct doca_dpdk_action_mark_data mark;
 	};
@@ -203,8 +203,8 @@ struct doca_dpdk_action_entry {
 	struct rte_flow_action *action;
 	struct doca_dpdk_action_data action_data;
 	int (*modify_action)(struct doca_dpdk_pipe *pipe,
-            struct doca_dpdk_action_entry *entry,
-            struct doca_flow_actions *action);
+	struct doca_dpdk_action_entry *entry,
+	struct doca_flow_actions *action);
 };
 
 struct doca_dpdk_pipe {
@@ -350,13 +350,16 @@ struct doca_flow_pipe_entry *doca_dpdk_add_pipe_entry(
 	struct doca_flow_monitor *mon, struct doca_flow_fwd *cfg,
 	struct doca_flow_error *err);
 
-int doca_dpdk_init_port(uint16_t port_id);
+int doca_dpdk_init_port(struct doca_flow_port *port);
 int doca_dpdk_free_pipe_entry(uint16_t portid,
 			      struct doca_flow_pipe_entry *entry);
 
 struct doca_flow_port *doca_dpdk_port_start(struct doca_flow_port_cfg *cfg,
 					    struct doca_flow_error *err);
+int doca_dpdk_port_stop(struct doca_flow_port *port);
 void doca_dpdk_destroy(uint16_t port_id);
+void doca_dpdk_free_pipe(uint16_t portid, struct doca_flow_pipe *pipe);
+void doca_dpdk_flush_pipe(uint16_t port_id);
 void doca_dpdk_dump_pipe(uint16_t port_id);
 
 void doca_dpdk_enable_acl(void);

--- a/examples/vnet/doca_dpdk_priv.h
+++ b/examples/vnet/doca_dpdk_priv.h
@@ -49,9 +49,10 @@ struct doca_flow_pipe {
 struct doca_flow_port {
 	uint32_t port_id;
 	int idx;
-
 	rte_spinlock_t pipe_lock;
 	LIST_HEAD(, doca_flow_pipe) pipe_list;
+	void *default_jump_flow;
+	void *default_rss_flow;
 	uint8_t user_data[0];
 };
 

--- a/examples/vnet/doca_flow.c
+++ b/examples/vnet/doca_flow.c
@@ -24,12 +24,14 @@
 DOCA_LOG_MODULE(doca_flow);
 
 
-uint8_t *doca_flow_port_priv_data(struct doca_flow_port *p)
+uint8_t *
+doca_flow_port_priv_data(struct doca_flow_port *p)
 {
 	return &p->user_data[0];
 }
 
-int doca_flow_init(struct doca_flow_cfg *cfg, struct doca_flow_error *err)
+int
+doca_flow_init(struct doca_flow_cfg *cfg, struct doca_flow_error *err)
 {
 	DOCA_LOG_INFO("total sessions = %d\n", cfg->total_sessions);
 	if (err)
@@ -45,7 +47,8 @@ int doca_flow_init(struct doca_flow_cfg *cfg, struct doca_flow_error *err)
  *
  * @return
  */
-struct doca_flow_pipe_entry *doca_flow_pipe_add_entry(
+struct doca_flow_pipe_entry *
+doca_flow_pipe_add_entry(
 	uint16_t pipe_queue, struct doca_flow_pipe *pipe,
 	struct doca_flow_match *match, struct doca_flow_actions *actions,
 	struct doca_flow_monitor *mon, struct doca_flow_fwd *fwd,
@@ -53,13 +56,13 @@ struct doca_flow_pipe_entry *doca_flow_pipe_add_entry(
 {
 	if (pipe == NULL || match == NULL || actions == NULL)
 		return NULL;
-	pipe_queue = pipe_queue;
 	return doca_dpdk_add_pipe_entry(pipe, pipe_queue, match, actions, mon,
 	                                  fwd, err);
 }
 
-int doca_flow_rm_entry(uint16_t pipe_queue,
-		       struct doca_flow_pipe_entry *entry)
+int
+doca_flow_pipe_rm_entry(uint16_t pipe_queue,
+			struct doca_flow_pipe_entry *entry)
 {
 	DOCA_LOG_INFO("(pipe %d) HW release id%d", pipe_queue, entry->id);
 	/* doca_dpdk_free_flow(0, entry->pipe_entry); */
@@ -75,7 +78,8 @@ int doca_flow_rm_entry(uint16_t pipe_queue,
  *
  * @return
  */
-struct doca_flow_port *doca_flow_port_start(struct doca_flow_port_cfg *cfg,
+struct doca_flow_port *
+doca_flow_port_start(struct doca_flow_port_cfg *cfg,
 					    struct doca_flow_error *err)
 {
 	struct doca_flow_port *port = NULL;
@@ -109,11 +113,12 @@ struct doca_flow_port *doca_flow_port_start(struct doca_flow_port_cfg *cfg,
  *
  * @return
  */
-int doca_flow_port_stop(struct doca_flow_port *port)
+int
+doca_flow_port_stop(struct doca_flow_port *port)
 {
 	if (port != NULL)
 		DOCA_LOG_INFO("port id = %d stopped\n", port->port_id);
-	return 0;
+	return doca_dpdk_port_stop(port);
 }
 
 struct doca_flow_pipe *
@@ -126,12 +131,26 @@ doca_flow_create_pipe(struct doca_flow_pipe_cfg *cfg,
 	return doca_dpdk_create_pipe(cfg, fwd, err);
 }
 
-void doca_flow_destroy(uint16_t port_id)
+void
+doca_flow_destroy_pipe(uint16_t port_id, struct doca_flow_pipe *pipe)
+{
+	doca_dpdk_free_pipe(port_id, pipe);
+}
+
+void
+doca_flow_flush_pipe(uint16_t port_id)
+{
+	doca_dpdk_flush_pipe(port_id);
+}
+
+void
+doca_flow_destroy(uint16_t port_id)
 {
 	doca_dpdk_destroy(port_id);
 }
 
-void doca_flow_dump_pipe(uint16_t port_id)
+void
+doca_flow_dump_pipe(uint16_t port_id)
 {
 	doca_dpdk_dump_pipe(port_id);
 }

--- a/examples/vnet/doca_flow.h
+++ b/examples/vnet/doca_flow.h
@@ -69,7 +69,7 @@ enum doca_flow_error_type {
 	DOCA_ERROR_UNSUPPORTED,
 	DOCA_ERROR_TABLE_IS_FULL,
 	DOCA_ERROR_NOMORE_PIPE_RESOURCE,
-	DOCA_ERROR_PIPE_BUILD_IMTE_ERROR,
+	DOCA_ERROR_PIPE_BUILD_ITEM_ERROR,
 	DOCA_ERROR_PIPE_BUILD_ACTION_ERROR,
 	DOCA_ERROR_OOM,
 };
@@ -372,8 +372,8 @@ int doca_flow_pipe_update_default(uint16_t pipe_queue,
  *
  * @return
  */
-int doca_flow_rm_entry(uint16_t pipe_queue,
-		       struct doca_flow_pipe_entry *entry);
+int doca_flow_pipe_rm_entry(uint16_t pipe_queue,
+			    struct doca_flow_pipe_entry *entry);
 
 /**
  * @brief - extract information about specific entry
@@ -400,8 +400,9 @@ int doca_flow_query(struct doca_flow_pipe_entry *pe,
 bool doca_flow_query_aging(struct doca_flow_pipe_entry *arr, int arr_len,
 			   int *n);
 
+void doca_flow_destroy_pipe(uint16_t port_id, struct doca_flow_pipe *pipe);
+void doca_flow_flush_pipe(uint16_t port_id);
 void doca_flow_destroy(uint16_t port_id);
 void doca_flow_dump_pipe(uint16_t port_id);
 
-//struct doca_flow_fwd *doca_flow_fwd_cast(struct doca_flow_fwd_tbl *tbl);
 #endif

--- a/examples/vnet/gw.c
+++ b/examples/vnet/gw.c
@@ -515,7 +515,7 @@ gw_pipe_add_ol_to_ol_entry(struct doca_pkt_info *pinfo,
 
 static void gw_rm_pipe_entry(struct doca_flow_pipe_entry *entry)
 {
-	doca_flow_rm_entry(0, entry);
+	doca_flow_pipe_rm_entry(0, entry);
 }
 
 static int gw_create(void)

--- a/examples/vnet/simple_fwd.c
+++ b/examples/vnet/simple_fwd.c
@@ -65,8 +65,8 @@ sf_aged_flow_cb(struct doca_ft_user_ctx *ctx)
 	struct sf_entry *entry = (struct sf_entry *)&ctx->data[0];
 
 	if (entry->is_hw) {
-            doca_flow_rm_entry(0, entry->hw_entry);
-            entry->hw_entry = NULL;
+		doca_flow_pipe_rm_entry(0, entry->hw_entry);
+		entry->hw_entry = NULL;
 	}
 }
 


### PR DESCRIPTION
DoCA flow supports the below paired API:
 - doca_flow_init and doca_flow_destroy
 - doca_flow_port_start and doca_flow_port_stop
 - doca_flow_create_pipe and doca_flow_destroy_pipe
 - doca_flow_pipe_add_entry and doca_flow_pipe_rm_entry

Rename the doca_flow_rm_entry into doca_flow_pipe_rm_entry;
Update the doca_flow_stop and doca_flow_destory
Expose two news API doca_flow_destroy_pipe and doca_flow_flush_pipe

Signed-off-by: Jiawei Wang <jiaweiw@nvidia.com>