### PR TITLE
doca-dpdk: Fix wrongly masking port upon init

### DIFF
--- a/examples/vnet/doca_dpdk.c
+++ b/examples/vnet/doca_dpdk.c
@@ -1665,7 +1665,6 @@ doca_dpdk_port_start(struct doca_flow_port_cfg *cfg,
 
 	if (port == NULL)
 		return NULL;
-	memset(port, 0, sizeof(struct doca_flow_port));
 	if (!doca_dpdk_save_port(port))
 		goto fail_port_start;
 	return port;


### PR DESCRIPTION
When creating a doca port the function doca_dpdk_port_start
is called, where we wrongly mask the port allocated from the dpdk
port. Fix it.

Signed-off-by: Salem Sol <salems@nvidia.com>